### PR TITLE
Allow to skip report if no data or details are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ profiles:
       - "unsub"
       - "spam"
       - "queued"
+    skip_if_no_details: False # Default=False
+    skip_if_no_data: True # Default=False
 
 subaccount_reports:
   - name: "SUBACCOUNT TEST" # Name of the Mailjet subaccount
@@ -71,6 +73,8 @@ subaccount_reports:
     recipients:
       - to_email: "john.doe@example.com" # Email address to send the report to
         to_name: "John Doe" # Name to send the report to
+    skip_if_no_details: True # Default derived from profile setting
+    skip_if_no_data: True # Default derived from profile setting
 ```
 
 ## Running the script

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ profiles:
       - "unsub"
       - "spam"
       - "queued"
-    skip_if_no_details: False # Default=False
-    skip_if_no_data: True # Default=False
+    skip_if_no_details: false # Default=False
+    skip_if_no_data: true # Default=False
 
 subaccount_reports:
   - name: "SUBACCOUNT TEST" # Name of the Mailjet subaccount
@@ -73,8 +73,8 @@ subaccount_reports:
     recipients:
       - to_email: "john.doe@example.com" # Email address to send the report to
         to_name: "John Doe" # Name to send the report to
-    skip_if_no_details: True # Default derived from profile setting
-    skip_if_no_data: True # Default derived from profile setting
+    skip_if_no_details: true # Default derived from profile setting
+    skip_if_no_data: true # Default derived from profile setting
 ```
 
 ## Running the script

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ profiles:
       - "unsub"
       - "spam"
       - "queued"
-    skip_if_no_details: false # Default=False
-    skip_if_no_data: true # Default=False
+    skip_if_no_details: false # Default=false
+    skip_if_no_data: true # Default=false
 
 subaccount_reports:
   - name: "SUBACCOUNT TEST" # Name of the Mailjet subaccount

--- a/mailjet_state_reporter/__init__.py
+++ b/mailjet_state_reporter/__init__.py
@@ -173,6 +173,21 @@ def send_report(
     global_settings: dict[str, Any] = config.get("global_settings", {})
     status_translations: dict[str, Any] = config.get("status_translations", {})
 
+    skip_if_no_details = subaccount.get(
+        "skip_if_no_details",
+        subaccount["profile_details"].get("skip_if_no_details", False),
+    )
+    skip_if_no_data = subaccount.get(
+        "skip_if_no_data", subaccount["profile_details"].get("skip_if_no_data", False)
+    )
+    if (
+        skip_if_no_details
+        and not message_details
+        or skip_if_no_data
+        and not message_stats
+    ):
+        return False
+
     timezone = global_settings.get("timezone", "Europe/Amsterdam")
     report_time_format = global_settings.get("time_format", "%Y-%m-%d %H:%M:%S")
     subaccount_time_format = subaccount["profile_details"].get(

--- a/mailjet_state_reporter/__init__.py
+++ b/mailjet_state_reporter/__init__.py
@@ -180,11 +180,8 @@ def send_report(
     skip_if_no_data = subaccount.get(
         "skip_if_no_data", subaccount["profile_details"].get("skip_if_no_data", False)
     )
-    if (
-        skip_if_no_details
-        and not message_details
-        or skip_if_no_data
-        and not message_stats
+    if (skip_if_no_details and not message_details) or (
+        skip_if_no_data and not message_stats
     ):
         return False
 


### PR DESCRIPTION
## Summary
Add profile options:

```yaml
    skip_if_no_details: false # Default=false
    skip_if_no_data: true # Default=false
```

Allow to override these per settings subaccount report.
