### PR TITLE
Set UID 2001 for container user pythonrt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk upgrade \
       nano less libxml2 python3-dev libxslt-dev libxml2-dev bash openssl-dev libffi-dev \
     && ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
     && update-ca-certificates \
-    && addgroup -S appgroup && adduser -S pythonrt -G appgroup \
+    && addgroup -S appgroup && adduser -S pythonrt -G appgroup -u 2001 \
     && mkdir -p /config \
     && chown -R pythonrt:appgroup /config
 

--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ docker run --rm \
 jbouwh/mailjet-state-reporter:latest
 ```
 
-> `~/config/settings.yaml`: is the configuration file; `~/config/sync_state.json`: is generated bt the script and should be outside the container and persistant, as it stores the last processed timestamp here.
+> The `CONFIG_FILE` `~/config/settings.yaml` is the configuration file; The `SYNC_STATE` file `~/config/sync_state.json` is generated bt the script and should be outside the container and persistent, as it stores the last processed timestamp here. The `~/config/sync_state.json`. The user (``pythonrt`) in the docker container has UID 2001, so make sure to assign the correct access rights.


### PR DESCRIPTION
As the `SYNC_STATE` file should have read/write access and the config file Read access, it is important to set the UID, to allow setting proper access rights outside the container, because the user in the container is not `root`.